### PR TITLE
Make it clear that hello-world.rs isn't better than this introduction to Rust

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use r_i18n::I18n;
 
 unsafe fn strange() -> bool { let _x: bool = return true; }
 
-unsafe fn funny() {
+unsafe fn the_funny() {
     unsafe fn f(_x: ()) { }
     f(return);
 }


### PR DESCRIPTION
This Is a PR To Make It Clear That hello-world.rs That Is Memory Safe, Blazingly Fast, Written In Rust, And Has Over 700 Dependencies, Is Not Better Than A CC BY-SA Comprehensive Blog Post Hosted on My Handcrafted Zola Site On GitLab Pages Meant To Teach You Rust That Is Called Learning Rust With Entirely Too Descriptive Names That Gets Insanely Convoluted And Teaches You Nothing In The End Leaving You Wondering If You Still Want To Pursue Programming As A Career And That Is Available With An Entirely Too Compliant Atom Feed And Uses CSS And HTML Features Too New For The Nintendo 3DS So You Need To Translate It To Raw Text And Can Not Read It From The Original Source Which Was Inspired By Making A Rust Enum With Generic Parameters Entirely Too Descriptive And Resulted In A Type With A Signature Of 
```rust
enum PotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndCopyForTheFirstEnumVariantWhichContainsCellAndCellRequiresTypesToBeCopyWhichMeansThatTheTypeMustBeATriviallyClonableTypeThatIsAbleToBeCopiedByteForByteWithMemcpyOrASimilarInstructionAlsoForYourInformationEnumsInTheRustProgrammingLanguageAreActuallyTaggedUnionsAndThusAlsoSumTypes<TypeOfTheValueInThePotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndNeedsToBeCopyForTheInnatelyMutableCellEnumVariantWithOneGenericParameterEnumVariant> {
    InnatelyMutableCellEnumVariantWithOneGenericParameter(Cell<TypeOfTheValueInThePotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndNeedsToBeCopyForTheInnatelyMutableCellEnumVariantWithOneGenericParameterEnumVariant>),
    NotInnatelyMutableEnumVariantWithOneGenericParameterThatIsNotACell(TypeOfTheValueInThePotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndNeedsToBeCopyForTheInnatelyMutableCellEnumVariantWithOneGenericParameterEnumVariant),
}

impl TraitForPotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndCopyForTheFirstEnumVariantWhichContainsCellAndCellRequiresTypesToBeCopyThatAllowsYouToDoCertainSpecialThingsWithThisThatICannotDescribeDueToHavingNoThoughtsRightNow for PotentiallyInnatelyMutableEnumWithTwoSumVariantsWithOneGenericParameterThatMightBeMutableThatIsTAndNeedsToBeFilledInAndCopyForTheFirstEnumVariantWhichContainsCellAndCellRequiresTypesToBeCopyWhichMeansThatTheTypeMustBeATriviallyClonableTypeThatIsAbleToBeCopiedByteForByteWithMemcpyOrASimilarInstructionAlsoForYourInformationEnumsInTheRustProgrammingLanguageAreActuallyTaggedUnionsAndThusAlsoSumTypes {

}
```
